### PR TITLE
Update to work with Babel 6.x (Presets)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,1 @@
-{
-  "presets": ["es2015", "react"]
-}
+{ "presets": ["es2015", "react"] }

--- a/bootstrapper.js
+++ b/bootstrapper.js
@@ -1,4 +1,2 @@
-// install babel hooks in the main process
-require('babel/register');
-
+require('babel-register');
 require('./main.js');

--- a/bootstrapper.js
+++ b/bootstrapper.js
@@ -1,2 +1,3 @@
+// install babel hooks in the main process
 require('babel-register');
 require('./main.js');

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>electron es6 react boilerplate</title>
     <script>
+      // install babel hooks in the renderer process
       require('babel-register');
       require('./scripts/main');
     </script>

--- a/index.html
+++ b/index.html
@@ -2,18 +2,12 @@
 <html>
   <head>
     <title>electron es6 react boilerplate</title>
+    <script>
+      require('babel-register');
+      require('./scripts/main');
+    </script>
   </head>
 
   <body>
   </body>
-
-  <script>
-    // install babel hooks in the renderer process
-    require('babel/register');
-
-    var React = require('react');
-    var Main = require('./views/main.jsx');
-
-    React.render(React.createElement(Main, null), document.body);
-  </script>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,3 @@
-'use babel';
-
 import app from 'app';
 import BrowserWindow from 'browser-window';
 
@@ -13,7 +11,7 @@ app.on('window-all-closed', () => {
 
 app.on('ready', () => {
   mainWindow = new BrowserWindow({width: 800, height: 600});
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "main": "bootstrapper.js",
   "dependencies": {
-    "babel": "*",
-    "react": "*"
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-register": "^6.3.13",
+    "react": "*",
+    "react-dom": "^0.14.3"
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Main from '../views/main.jsx';
+
+window.onload = function(){
+  ReactDOM.render(<Main />, document.body);
+}


### PR DESCRIPTION
This updates it to work in Babel's newest releases (6.x).  It includes the ES2015 and React presets for transforming.  

Fixes #2
