### PR TITLE
remove boostrapper.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ without depending on any package manager besides `npm`.
 
 ## How?
 
-The main entry point is `bootstrapper.js`, which registers Babel and loads the
-real entry point `main.js`. This is necessary to allow `main.js` to make use of
-Babel's features.
+The Node and Electron binaries both take a parameter `-r` that automatically
+requires a module before the rest of the code.  The `npm start` script is
+modified using this, which registers Babel and loads the entry point `main.js`.
 
 The renderer entry point `index.html` does basically the same, but loads the
 `scripts/main.js` file, which renders the `views/main.jsx` component into the `body`.

--- a/bootstrapper.js
+++ b/bootstrapper.js
@@ -1,3 +1,0 @@
-// install babel hooks in the main process
-require('babel-register');
-require('./main.js');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "electron-es6-react",
   "version": "0.1.0",
-  "main": "bootstrapper.js",
+  "main": "main.js",
   "license": "MIT",
   "repository": "b52/electron-es6-react",
   "scripts": {
-    "start": "electron ."
+    "start": "electron -r babel-register ."
   },
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
by using the electron -r flag we don't need the extra file:

    electron -r babel-register .